### PR TITLE
fix(env_d): remove unstable libss3-dev dependency.

### DIFF
--- a/docker/env/d/Dockerfile
+++ b/docker/env/d/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     gcc=4:11.2.0-1ubuntu1 \
     dub=1.27.0-2 \
     zlib1g-dev=1:1.2.11.dfsg-2ubuntu9.2 \
-    libssl-dev=3.0.2-0ubuntu1.12 && \
+    libssl3=3.0.2-0ubuntu1.13 && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /graphexperiment


### PR DESCRIPTION
This PR consists of removing an unstable dependency in the `libss3` package, in a docker container. We will use the normal package.